### PR TITLE
Pull docker image to TravisCI instead of building it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ services:
 
 before_install:
   - docker pull mkerins/mass
-  - docker build -t mkerins/mass .
 
 install:
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
   - docker
 
 before_install:
+  - docker pull mkerins/mass
   - docker build -t mkerins/mass .
 
 install:


### PR DESCRIPTION
Pull latest mkerins/mass image from docker hub instead of building it, will need to make sure the image is updated when necessary. 

Closes #13 