### PR TITLE
Add pagination to list views

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN pip install pip --upgrade && \
 
 RUN apt-key add etc/apt/Release.key && \
     echo 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/ /' >> /etc/apt/sources.list.d/bro.list && \
-    apt-get update && apt-get install -y bro supervisor p7zip-full clamav-daemon clamdscan netcat-openbsd nginx
+    apt-get update && apt-get install -y bro curl supervisor p7zip-full clamav-daemon clamdscan netcat-openbsd nginx
 
 RUN mkdir -p /etc/supervisor/conf.d/
 

--- a/filestore/models.py
+++ b/filestore/models.py
@@ -194,6 +194,9 @@ class File(models.Model):
     def __str__(self):
         return '{} ({})'.format(self.file_name, self.file_type)
 
+    class Meta:
+        ordering = ['file_name']
+
 
 class Folder(models.Model):
     """Record of folders scanned"""
@@ -222,3 +225,6 @@ class Folder(models.Model):
 
     def __str__(self):
         return self.path
+    
+    class Meta:
+        ordering = ['path']

--- a/filestore/templates/filestore/file_list.html
+++ b/filestore/templates/filestore/file_list.html
@@ -69,5 +69,28 @@
     {% endif %}
   </div>
   </form>
+  {% if files.has_other_pages %}
+    <nav class="pagination is-centered" role="navigation" aria-label="pagination">
+    {% if files.has_previous %}
+      <a class="pagination-previous" href="?page={{ files.previous_page_number }}">Previous</a>
+    {% else %}
+      <a class="pagination-previous" disabled>Previous</a>
+    {% endif %}
+    {% if files.has_next %}
+      <a class="pagination-next" href="?page={{ files.next_page_number }}">Next</a>
+    {% else %}
+      <a class="pagination-next" disabled>Next</a>
+    {% endif %}
+      <ul class="pagination-list">
+      {% for i in files.paginator.page_range %}
+        {% if files.number == i %}
+          <li><a class="pagination-link is-current">{{ i }}</a></li>
+        {% else %}
+          <li><a class="pagination-link" href="?page={{ i }}">{{ i }}</a></li>
+        {% endif %}
+      {% endfor %}
+      </ul>
+    </nav>
+  {% endif %}
   <script type="text/javascript" src="{% static 'filestore/file_list.js' %}"></script>
 {% endblock %}

--- a/filestore/templates/filestore/folder_list.html
+++ b/filestore/templates/filestore/folder_list.html
@@ -51,5 +51,28 @@
     {% endif %}
   </div>
 </form>
+{% if folders.has_other_pages %}
+<nav class="pagination is-centered" role="navigation" aria-label="pagination">
+{% if folders.has_previous %}
+  <a class="pagination-previous" href="?page={{ folders.previous_page_number }}">Previous</a>
+{% else %}
+  <a class="pagination-previous" disabled>Previous</a>
+{% endif %}
+{% if folders.has_next %}
+  <a class="pagination-next" href="?page={{ folders.next_page_number }}">Next</a>
+{% else %}
+  <a class="pagination-next" disabled>Next</a>
+{% endif %}
+  <ul class="pagination-list">
+  {% for i in folders.paginator.page_range %}
+    {% if folders.number == i %}
+      <li><a class="pagination-link is-current">{{ i }}</a></li>
+    {% else %}
+      <li><a class="pagination-link" href="?page={{ i }}">{{ i }}</a></li>
+    {% endif %}
+  {% endfor %}
+  </ul>
+</nav>
+{% endif %}
 <script type="text/javascript" src="{% static 'filestore/folder_list.js' %}"></script>
 {% endblock %}

--- a/filestore/tests/test_views.py
+++ b/filestore/tests/test_views.py
@@ -17,9 +17,21 @@ class FileViewTests(TestCase):
             except FileNotFoundError:
                 pass
 
-    def test_file_list_view(self):
-        resp = self.client.get(reverse('file-list'))
-        self.assertEqual(resp.status_code, 200)
+    def test_index_page_redirects_to_files(self):
+        resp = self.client.get(reverse('index'))
+        self.assertEqual(resp.status_code, 302)
+
+    def test_file_list_view_pagination(self):
+        page_nums = []
+        resp = self.client.get(reverse('file-list'), {'page': 10})
+        page_nums.append(resp.context_data.get('files').number)
+        resp = self.client.get(reverse('file-list'), {'page': 'notanumber'})
+        page_nums.append(resp.context_data.get('files').number)
+        resp = self.client.get(reverse('file-list'), {'page': None})
+        page_nums.append(resp.context_data.get('files').number)
+        resp = self.client.get(reverse('file-list'), {'page': -1})
+        page_nums.append(resp.context_data.get('files').number)
+        self.assertTrue(all(x == 1 for x in page_nums))
 
     def test_file_add_view_error(self):
         """Shouldn't be able to create a File record without uploading a file"""
@@ -105,9 +117,17 @@ class FolderViewTests(TestCase):
             except FileNotFoundError:
                 pass
 
-    def test_folder_list_view(self):
-        resp = self.client.get(reverse('folder-list'))
-        self.assertEqual(resp.status_code, 200)
+    def test_folder_list_view_pagination(self):
+        page_nums = []
+        resp = self.client.get(reverse('folder-list'), {'page': 10})
+        page_nums.append(resp.context_data.get('folders').number)
+        resp = self.client.get(reverse('folder-list'), {'page': 'notanumber'})
+        page_nums.append(resp.context_data.get('folders').number)
+        resp = self.client.get(reverse('folder-list'), {'page': None})
+        page_nums.append(resp.context_data.get('folders').number)
+        resp = self.client.get(reverse('folder-list'), {'page': -1})
+        page_nums.append(resp.context_data.get('folders').number)
+        self.assertTrue(all(x == 1 for x in page_nums))
 
     def test_folder_add_view_empty_path(self):
         """Shouldn't be able to create a Folder record with no path"""

--- a/filestore/urls.py
+++ b/filestore/urls.py
@@ -2,7 +2,8 @@ from django.urls import path
 from filestore import views
 
 urlpatterns = [
-    path('', views.FileList.as_view(), name='file-list'),
+    path('', views.index, name='index'),
+    path('files/', views.FileList.as_view(), name='file-list'),
     path('add/', views.FileCreate.as_view(), name='file-create'),
     path('detail/<str:slug>', views.FileDetail.as_view(), name='file-detail'),
     path('delete/<str:slug>', views.FileDelete.as_view(), name='file-delete'),

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -14,4 +14,5 @@ freshclam
 /etc/init.d/clamav-daemon start
 rm -rf debug.log
 python manage.py loaddata init_data.json
+curl -s -o /dev/null -w "%{http_code}" -L http://localhost:8000/update_clamav_db
 python manage.py runserver 0.0.0.0:8000

--- a/run_prod.sh
+++ b/run_prod.sh
@@ -12,4 +12,5 @@ freshclam
 /etc/init.d/clamav-daemon start
 python manage.py loaddata init_data.json
 python manage.py collectstatic --noinput
+curl -s -o /dev/null -w "%{http_code}" -L http://localhost:8000/update_clamav_db
 supervisord -c /etc/supervisor/supervisord.conf -n

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,7 +3,6 @@
 pip install -r requirements/test.txt 
 export DJANGO_SETTINGS_MODULE=mass.settings.devel
 find {filestore,mass} -name "__pycache__" | xargs rm -rf
-rm -rf mass/db.sqlite3
 rm -rf files/*
 rm -rf */migrations/*
 cp etc/clamav/*.cvd /var/lib/clamav/

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,19 @@ envlist =
 	coverage-report
 	flake8
 
-passenv = TOXENV CI TRAVIS TRAVIS_*
-skipsdist=True
+passenv =
+    TOXENV
+    CI
+    TRAVIS
+    TRAVIS_*
+skipsdist =
+    True
 
 [testenv]
 passenv =
-  CI
-  TRAVIS
-  TRAVIS_*
+    CI
+    TRAVIS
+    TRAVIS_*
 
 deps =
     -rrequirements/test.txt
@@ -32,7 +37,7 @@ deps =
 	coverage
 
 skip_install =
-	true
+	True
 
 commands =
 	coverage report -m
@@ -42,7 +47,7 @@ deps =
 	flake8
 
 skip_install =
-	true
+	True
 
 commands =
     - flake8 --max-line-length=119 filestore/ mass/


### PR DESCRIPTION
Tried to use MultipleObjectMixin but it wasn't playing nice with
FormView so used Paginator() directly

filestore/models.py
- added default ordering so pagination results are more predictable

filestore/templates/filestore/{file_list.html,folder_list.html}
- added pagination <nav> block to handle the display and operation of
  the expected pagination experience (next, previous, etc.)

filestore/tests/test_views.py
- added test to make sure requests to "/" get redirected to "/files"
- added File and Folder tests to check pagination works properly

filestore/urls.py
- to support pagination changed the FileList view to be on "/files"
  instead of "/"

filestore/views.py
- added simple index view function to redirect requests to "/" to
  "/files"
- removed unnecessary get_queryset() static methods
- FileList and FolderList views now support pagination. Requests to
  invalid or non-existant pages will go to page 1

Misc
- run_dev.sh and run_tests.sh: hit the "/update_clamav_db" endpoint
  to update the ClamAV DB
- format tox.ini to be consistent